### PR TITLE
Incorrect event type for banner loaded callback

### DIFF
--- a/www/ads/BannerAd.js
+++ b/www/ads/BannerAd.js
@@ -133,7 +133,7 @@
    */
   var BannerAd = {
     Events: {
-      LOADED: 'loaded',
+      AVAILABLE: 'available',
       ERROR: 'error',
       CLICKED: 'clicked'
     },


### PR DESCRIPTION
The "LOADED" type is not what the plugin gets from the SDK. "AVAILABLE" type is the correct one and tested to be working properly.